### PR TITLE
Added some support for a generic device

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@
 
 ## Basic Information   
 To get setup just run `pip install -r requirements.txt`.
-Set an **environment variable** for the `WANDB_USER_NAME` to sync correctly w/ Wandb.
+- Set an **environment variable** for the `WANDB_USER_NAME` to sync correctly w/ Wandb.
+- Set an envvar for the `DEVICE_TYPE` to use non-cuda device.
 To launch training run: setup a config yaml file, then run `python -m train /path/to/config.yaml` (or `torchrun`).
 
 ## How Do I Create A New Model?  

--- a/configs/titok.yml
+++ b/configs/titok.yml
@@ -14,6 +14,7 @@ model:
 
   patch_size: 4
   causal: False
+  mimetic_init: True
 
 train:
   trainer_id: rec

--- a/owl_vaes/data/mnist.py
+++ b/owl_vaes/data/mnist.py
@@ -1,10 +1,13 @@
-from datasets import load_dataset
-
 import torch
 import torch.distributed as dist
-from torch.utils.data import DataLoader
-from PIL import Image
 import torchvision.transforms.functional as TF
+from datasets import load_dataset
+from PIL import Image
+from torch.utils.data import DataLoader
+
+from owl_vaes.utils.get_device import DeviceManager
+
+device = DeviceManager.get_device()
 
 def get_loader(batch_size):
     
@@ -53,7 +56,8 @@ def get_loader(batch_size):
         shuffle=(train_sampler is None),
         sampler=train_sampler,
         drop_last=True,
-        collate_fn=collate_fn
+        collate_fn=collate_fn,
+        generator=torch.Generator(device)
     )
 
     return train_loader

--- a/owl_vaes/discriminators/res.py
+++ b/owl_vaes/discriminators/res.py
@@ -2,14 +2,15 @@
 R3Gan style resnet based VAE
 """
 
-from ..nn.resnet import DownBlock, SameBlock
-from ..nn.normalization import GroupNorm
-
-import torch.nn.functional as F
 import torch
+import torch.nn.functional as F
 from torch import nn
 
-import einops as eo
+from owl_vaes.utils.get_device import DeviceManager
+
+from ..nn.resnet import DownBlock, SameBlock
+
+device = DeviceManager.get_device()
 
 class R3GANDiscriminator(nn.Module):
     def __init__(self, config):
@@ -71,9 +72,9 @@ if __name__ == "__main__":
         ch_max:int= 256
         blocks_per_stage:int= 2
 
-    model = ResDiscriminator(DummyConfig()).bfloat16().cuda()
+    model = ResDiscriminator(DummyConfig()).bfloat16().to(device)
     with torch.no_grad():
-        x = torch.randn(1,3,256,256).bfloat16().cuda()
+        x = torch.randn(1,3,256,256).bfloat16().to(device)
         y = model._forward(x)
         print(y.shape)
 

--- a/owl_vaes/models/__init__.py
+++ b/owl_vaes/models/__init__.py
@@ -1,17 +1,17 @@
+from typing import Any
+
 from .dcae import DCAE
-from .titok import TiToKVAE
-from .titok_vq import TiToKVQVAE
 from .dcae_vq import DCVQVAE
 from .proxy_titok import ProxyTiToKVAE
+from .titok import TiToKVAE
+from .titok_vq import TiToKVQVAE
 
-def get_model_cls(model_id):
-    if model_id == "dcae":
-        return DCAE
-    if model_id == "titok":
-        return TiToKVAE
-    if model_id == "titok_vq":
-        return TiToKVQVAE
-    if model_id == "dcae_vq":
-        return DCVQVAE
-    if model_id == "proxy_titok":
-        return ProxyTiToKVAE
+
+def get_model_cls(model_id: str) -> Any:
+    return {
+        "dcae": DCAE,
+        "titok": TiToKVAE,
+        "titok_vq": TiToKVQVAE,
+        "dcae_vq": DCVQVAE,
+        "proxy_titok": ProxyTiToKVAE,
+    }.get(model_id)

--- a/owl_vaes/models/dcae.py
+++ b/owl_vaes/models/dcae.py
@@ -1,12 +1,15 @@
-import torch
-from torch import nn
-import torch.nn.functional as F
-
 import einops as eo
+import torch
+import torch.nn.functional as F
+from torch import nn
 
-from ..nn.resnet import UpBlock, DownBlock, SameBlock
-from ..nn.sana import SpaceToChannel, ChannelToSpace
+from owl_vaes.utils.get_device import DeviceManager
+
 from ..nn.normalization import GroupNorm
+from ..nn.resnet import DownBlock, SameBlock, UpBlock
+from ..nn.sana import ChannelToSpace, SpaceToChannel
+
+device = DeviceManager.get_device()
 
 class Encoder(nn.Module):
     def __init__(self, config : 'ResNetConfig'):
@@ -143,10 +146,10 @@ if __name__ == "__main__":
     from ..configs import Config
 
     cfg = Config.from_yaml("configs/1d_diff_exps/teacher_1.yml").model
-    model = DCAE(cfg).float().cuda()
+    model = DCAE(cfg).float().to(device)
 
-    with torch.cuda.amp.autocast(dtype=torch.bfloat16):
-        x = torch.randn(1, 3, 256, 256, device='cuda', dtype=torch.bfloat16)
+    with torch.autocast(device, dtype=torch.bfloat16):
+        x = torch.randn(1, 3, 256, 256, device=device, dtype=torch.bfloat16)
         rec, z, _ = model(x)
         
         print(f'Input shape: {x.shape}, dtype: {x.dtype}')

--- a/owl_vaes/models/proxy_titok.py
+++ b/owl_vaes/models/proxy_titok.py
@@ -1,12 +1,15 @@
+from copy import deepcopy
+
+import einops as eo
 import torch
 from torch import nn
-import torch.nn.functional as F
 
-from copy import deepcopy
-import einops as eo
+from owl_vaes.utils.get_device import DeviceManager
 
-from ..nn.attn import StackedTransformer, PatchProjIn, PatchProjOut
+from ..nn.attn import PatchProjIn, PatchProjOut, StackedTransformer
 from ..nn.embeddings import LearnedPosEnc
+
+device = DeviceManager.get_device()
 
 class Encoder(nn.Module):
     def __init__(self, config : 'TransformerConfig'):
@@ -103,10 +106,10 @@ if __name__ == "__main__":
         patch_size = 1
     )
 
-    model = TiToKVAE(cfg).float().cuda()
+    model = TiToKVAE(cfg).float().to(device)
 
-    with torch.cuda.amp.autocast(dtype=torch.bfloat16):
-        x = torch.randn(1, 32, 16, 16, device='cuda', dtype=torch.bfloat16)
+    with torch.autocast(dtype=torch.bfloat16):
+        x = torch.randn(1, 32, 16, 16, device=device, dtype=torch.bfloat16)
         rec, z = model(x)
         
         print(f'Input shape: {x.shape}, dtype: {x.dtype}')

--- a/owl_vaes/models/titok.py
+++ b/owl_vaes/models/titok.py
@@ -104,10 +104,10 @@ if __name__ == "__main__":
         patch_size = 1
     )
 
-    model = TiToKVAE(cfg).float().cuda()
+    model = TiToKVAE(cfg).float().to(device)
 
     with torch.autocast(device_type=device, dtype=torch.bfloat16):
-        x = torch.randn(1, 32, 16, 16, device='cuda', dtype=torch.bfloat16)
+        x = torch.randn(1, 32, 16, 16, device=device, dtype=torch.bfloat16)
         rec, z = model(x)
         
         print(f'Input shape: {x.shape}, dtype: {x.dtype}')

--- a/owl_vaes/muon.py
+++ b/owl_vaes/muon.py
@@ -1,11 +1,12 @@
-from torch.optim import AdamW
-
-from torch.optim.optimizer import Optimizer
-
-import os
 import torch
 import torch.distributed as dist
 from torch import Tensor
+from torch.optim import AdamW
+from torch.optim.optimizer import Optimizer
+
+from owl_vaes.utils.get_device import DeviceManager
+
+device = DeviceManager.get_device()
 
 def zeropower_via_newtonschulz5(G: Tensor, steps: int) -> Tensor:
     """
@@ -48,7 +49,7 @@ class Muon(torch.optim.Optimizer):
         params: list[Tensor] = [*params]
         param_groups = []
         for size in {p.numel() for p in params}:
-            b = torch.empty(world_size, size, dtype=torch.bfloat16, device="cuda")
+            b = torch.empty(world_size, size, dtype=torch.bfloat16, device=device)
             group = dict(params=[p for p in params if p.numel() == size],
                          update_buffer=b, update_buffer_views=[b[i] for i in range(world_size)])
             param_groups.append(group)

--- a/owl_vaes/nn/attn.py
+++ b/owl_vaes/nn/attn.py
@@ -1,18 +1,23 @@
-import torch
-from torch import nn
-import torch.nn.functional as F
-
-from .normalization import LayerNorm, RMSNorm, QKNorm
-from .embeddings import ImageRoPE
-from .mlp import MLP
-
 import einops as eo
-from .mimetic import mimetic_init
+import torch
+import torch.nn.functional as F
+from torch import nn
 
-torch.backends.cuda.enable_flash_sdp(enabled = True)
+from owl_vaes.configs import TransformerConfig
+
+from .mimetic import mimetic_init
+from .mlp import MLP
+from .normalization import LayerNorm, QKNorm
+from ..utils.get_device import DeviceManager
+
+device = DeviceManager.get_device()
+
+if device == "cuda":
+    torch.backends.cuda.enable_flash_sdp(enabled=True)
+
 
 class Attn(nn.Module):
-    def __init__(self, config : 'TransformerConfig'):
+    def __init__(self, config : TransformerConfig):
         super().__init__()
 
         self.n_heads = config.n_heads
@@ -110,8 +115,8 @@ class PatchProjOut(nn.Module):
         return x
 
 if __name__ == "__main__":
-    layer = PatchProjOut(64, 384, 3, 4).cuda().bfloat16()
-    x = torch.randn(1,256,384).cuda().bfloat16()
+    layer = PatchProjOut(64, 384, 3, 4).to(device).bfloat16()
+    x = torch.randn(1,256,384).to(device).bfloat16()
 
     with torch.no_grad():
         z = layer(x)

--- a/owl_vaes/trainers/__init__.py
+++ b/owl_vaes/trainers/__init__.py
@@ -1,8 +1,14 @@
-from .rec import RecTrainer
-from .proxy import ProxyTrainer
+from typing import Literal
 
-def get_trainer_cls(trainer_id):
-    if trainer_id == "rec":
-        return RecTrainer
-    if trainer_id == "proxy":
-        return ProxyTrainer
+from .proxy import ProxyTrainer
+from .rec import RecTrainer
+
+
+def get_trainer_cls(trainer_id: Literal["rec", "proxy"]):
+    match trainer_id:
+        case "rec":
+            return RecTrainer
+        case "proxy":
+            return ProxyTrainer
+        case _:
+            raise NotImplementedError

--- a/owl_vaes/utils/ddp.py
+++ b/owl_vaes/utils/ddp.py
@@ -1,26 +1,26 @@
-import torch 
-import torch.distributed as dist
 import os
+import torch.distributed as dist
 
-def setup(force=False):
+def setup(force: bool = False):
     if not force:
         try:
             dist.init_process_group(backend="nccl")
             global_rank = dist.get_rank()
             local_rank = int(os.environ.get("LOCAL_RANK", 0))
             world_size = dist.get_world_size()
-            
+
             return global_rank, local_rank, world_size
-        except:
+        except Exception:
             return 0, 0, 1
     else:
         dist.init_process_group(backend="nccl")
         global_rank = dist.get_rank()
         local_rank = int(os.environ.get("LOCAL_RANK", 0))
         world_size = dist.get_world_size()
-        
+
         return global_rank, local_rank, world_size
-        
+
+
 def cleanup():
     if dist.is_available() and dist.is_initialized():
         dist.destroy_process_group()

--- a/owl_vaes/utils/get_device.py
+++ b/owl_vaes/utils/get_device.py
@@ -1,0 +1,17 @@
+import os
+import torch
+
+class DeviceManager:
+    envvar = os.getenv("DEVICE_TYPE")
+    _device: str = envvar if isinstance(envvar, str) else "cuda"
+
+    @classmethod
+    def set_device(cls, device: str):
+        torch.set_default_device(device)
+        cls._device = device
+
+    @classmethod
+    def get_device(cls) -> str:
+        if cls._device is None:
+            raise ValueError("Device not initialized")
+        return cls._device

--- a/owl_vaes/utils/proxy_init.py
+++ b/owl_vaes/utils/proxy_init.py
@@ -5,12 +5,15 @@ Hard-coded for Proxy TiToK + DCAE for now
 
 import torch
 from torch import nn
-import torch.nn.functional as F
 
-from ..models.proxy_titok import ProxyTiToKVAE
-from ..models.dcae import Decoder
+from owl_vaes.utils.get_device import DeviceManager
+
 from ..configs import Config
-from . import versatile_load, prefix_filter
+from ..models.dcae import Decoder
+from ..models.proxy_titok import ProxyTiToKVAE
+from . import prefix_filter, versatile_load
+
+device = DeviceManager.get_device()
 
 class CombinedModule(nn.Module):
     def __init__(self, transformer_cfg, resnet_cfg):
@@ -55,14 +58,14 @@ if __name__ == "__main__":
     r_cfg = Config.from_yaml(r_cfg_path).model
 
     t_cfg.mimetic_init = False
-    model = CombinedModule(t_cfg, r_cfg).cuda().bfloat16()
+    model = CombinedModule(t_cfg, r_cfg).to(device).bfloat16()
     #model.load_ckpt(t_ckpt_path, r_ckpt_path)
 
     param_count = sum(p.numel() for p in model.parameters())
     print(f"Total parameters: {param_count:,}")
 
     with torch.no_grad():
-        x = torch.randn(1,3,256,256).cuda().bfloat16()
+        x = torch.randn(1,3,256,256).to(device).bfloat16()
         y = model(x)
         print(y.shape)
         

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "muon",
     "lpips",
     "dotenv>=0.9.9",
+    "torchtyping>=0.1.5",
 ]
 
 [dependency-groups]

--- a/train.py
+++ b/train.py
@@ -1,26 +1,28 @@
+import argparse
+import os
+
 from owl_vaes.configs import Config
 from owl_vaes.trainers import get_trainer_cls
-from owl_vaes.utils.ddp import setup, cleanup
-
-import argparse
-
-import os
-import torch
+from owl_vaes.utils.ddp import cleanup, setup
+from owl_vaes.utils.get_device import DeviceManager
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("config_path", type=str, help="Path to config YAML file")
+
+    parser.add_argument("--config_path", type=str, help="Path to config YAML file")
+
     args = parser.parse_args()
 
     cfg = Config.from_yaml(args.config_path)
-    
+
     global_rank, local_rank, world_size = setup()
-    torch.cuda.set_device(local_rank)
+
+    device = f"{os.getenv("DEVICE_TYPE")}:{local_rank}"
+    DeviceManager.set_device(device)
+
     trainer = get_trainer_cls(cfg.train.trainer_id)(
-        cfg.train,
-        cfg.wandb,
-        cfg.model,
-        global_rank, local_rank, world_size
+        cfg.train, cfg.wandb, cfg.model, global_rank, local_rank, world_size
     )
+
     trainer.train()
     cleanup()


### PR DESCRIPTION
Overrides for non-cuda device through an envvar. While its annoying to set envvars, I assume its only for dev so you can always set it permanently. If not provided, we want to default to `cuda`.