### PR TITLE
Image exp

### DIFF
--- a/configs/cod_128x_huge_kl.yml
+++ b/configs/cod_128x_huge_kl.yml
@@ -1,0 +1,53 @@
+# Config for a simple 256 -> 16 autoencoder
+model:
+  model_id: dcae
+  sample_size: [360,640]
+  channels: 3
+  latent_size: 4
+  latent_channels: 128
+
+  noise_decoder_inputs: 0.0
+  ch_0: 256
+  ch_max: 2048
+
+  encoder_blocks_per_stage: [3, 3, 3, 3, 3, 3, 3, 3]
+  decoder_blocks_per_stage: [3, 3, 3, 3, 3, 3, 3, 3]
+
+  checkpoint_grads: true
+
+train:
+  trainer_id: rec
+  data_id: s3_cod
+  target_batch_size: 128
+  batch_size: 16
+
+  epochs: 200
+
+  opt: AdamW
+  opt_kwargs:
+    lr: 1.0e-4
+    weight_decay: 1.0e-4
+    betas: [0.9, 0.95]
+    eps: 1.0e-15
+
+  lpips_type: convnext
+  loss_weights:
+    latent_reg: 1.0e-6
+    lpips: 12.0
+    se_reg: 0.0
+
+  scheduler: LinearWarmup
+  scheduler_kwargs:
+    warmup_steps: 3000
+    min_lr: 3.0e-6
+
+  checkpoint_dir: checkpoints/cod_128x_huge
+  resume_ckpt: checkpoints/cod_128x_huge/step_25000.pt
+
+  sample_interval: 1000
+  save_interval: 5000
+
+wandb:
+  name: ${env:WANDB_USER_NAME}
+  project: new_vaes
+  run_name: 128x_cod_scaled

--- a/owl_vaes/losses/basic.py
+++ b/owl_vaes/losses/basic.py
@@ -11,9 +11,10 @@ def latent_reg_loss(z: Tensor, target_var: float = 0.1) -> Tensor:
     # z is [b,c,h,w]
     # KL divergence between N(z, 0.1) and N(0,1)
     mu = z
-    log_target_var = 2 * torch.log(
-        torch.tensor(target_var, device=z.device, dtype=z.dtype)
-    )  # log(0.1^2)
+    log_target_var = 2*torch.log(z.float().std())
+    #log_target_var = 2 * torch.log(
+    #    torch.tensor(target_var, device=z.device, dtype=z.dtype)
+    #)  # log(0.1^2)
 
     kl = -0.5 * (1 + log_target_var - mu.pow(2) - log_target_var.exp())
     kl = einops.reduce(kl, "b ... -> b", reduction="sum").mean()

--- a/owl_vaes/trainers/rec.py
+++ b/owl_vaes/trainers/rec.py
@@ -111,6 +111,8 @@ class RecTrainer(BaseTrainer):
         accum_steps = max(1, accum_steps)
         self.scaler = torch.amp.GradScaler()
         ctx = torch.amp.autocast(f'cuda:{self.local_rank}', torch.bfloat16)
+        
+        self.load()
 
         # Timer reset
         timer = Timer()


### PR DESCRIPTION
- Switch ResNet backbone to same principals as AudioVAE
- Remove all normalizations and replace with weightnorm
- Remove middle blocks since they don't really seem to do anything
- Improve throughput quite a bit
- Results in incompatibilities with old checkpoints, please make note of this if using any old checkpoints (though they should be entirely phased our and depracated soon)
- Added *actual* kl loss: this should improve the diffusability of the latents but this needs to be tested
- > if it doesnt i will set kl weight to 0 on the default configs

See latest run with these changes here: https://wandb.ai/shahbuland/new_vaes/runs/kbt77oxz?nw=nwusershahbuland